### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Also, [SQLite support](/sql/) is currently being developed.
 -dontwarn android.support.annotation.**
 -dontwarn android.support.v7.widget.**
 -dontwarn android.support.design.widget.**
--dontwart androidx.**
+-dontwarn androidx.**
 -dontwarn okio.**
 
 # required by EnumSet


### PR DESCRIPTION
-dontwart androidx.** to -dontwarn androidx.** in ProGuard rules for Android
